### PR TITLE
Add StayHome wordmark logo and favicon

### DIFF
--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 40" fill="none">
+  <!-- House accent -->
+  <path d="M4 20L16 8L28 20V32H4V20Z" stroke="white" stroke-width="2" fill="none"/>
+  <path d="M10 32V22H22V32" stroke="white" stroke-width="2" fill="none"/>
+  <!-- Wordmark -->
+  <text x="36" y="28" font-family="system-ui, -apple-system, sans-serif" font-size="22" font-weight="600" fill="white" letter-spacing="-0.5">StayHome</text>
+</svg>

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,3 +1,5 @@
+import Image from "next/image";
+
 export default function AuthLayout({
   children,
 }: {
@@ -6,11 +8,9 @@ export default function AuthLayout({
   return (
     <div className="flex min-h-screen items-center justify-center bg-zinc-950">
       <div className="flex w-full max-w-md flex-col items-center gap-8 px-4">
-        <div className="text-center">
-          <h1 className="text-2xl font-semibold tracking-tight text-white">
-            StayHome
-          </h1>
-          <p className="mt-1 text-sm text-zinc-400">
+        <div className="flex flex-col items-center gap-2">
+          <Image src="/logo.svg" alt="StayHome" width={180} height={36} priority />
+          <p className="text-sm text-zinc-400">
             Home safety for aging in place
           </p>
         </div>

--- a/src/app/icon.svg
+++ b/src/app/icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <rect width="32" height="32" rx="6" fill="#09090b"/>
+  <path d="M6 16L16 6L26 16V26H6V16Z" stroke="white" stroke-width="2" fill="none"/>
+  <path d="M12 26V18H20V26" stroke="white" stroke-width="2" fill="none"/>
+</svg>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,11 @@
 import Link from "next/link";
+import Image from "next/image";
 
 export default function Home() {
   return (
     <div className="flex min-h-screen flex-col bg-zinc-950 text-white">
       <header className="flex items-center justify-between px-6 py-4">
-        <span className="text-lg font-semibold tracking-tight">StayHome</span>
+        <Image src="/logo.svg" alt="StayHome" width={160} height={32} priority />
         <Link
           href="/sign-in"
           className="rounded-lg border border-zinc-700 px-4 py-2 text-sm font-medium text-zinc-300 transition-colors hover:border-zinc-500 hover:text-white"

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { Logo } from "@/components/logo";
 import { UserButton } from "@clerk/nextjs";
 import { useQuery } from "convex/react";
 import { api } from "../../convex/_generated/api";
@@ -44,9 +45,7 @@ export function AppSidebar() {
   return (
     <aside className="flex h-full w-64 flex-col border-r border-zinc-800 bg-zinc-950">
       <div className="flex h-14 items-center border-b border-zinc-800 px-4">
-        <Link href="/dashboard" className="text-lg font-semibold tracking-tight text-white">
-          StayHome
-        </Link>
+        <Logo size="small" />
       </div>
 
       <nav className="flex-1 space-y-1 px-3 py-4">

--- a/src/components/logo.tsx
+++ b/src/components/logo.tsx
@@ -1,0 +1,26 @@
+import Image from "next/image";
+import Link from "next/link";
+
+export function Logo({
+  href = "/dashboard",
+  size = "default",
+}: {
+  href?: string;
+  size?: "small" | "default" | "large";
+}) {
+  const heights = { small: 24, default: 32, large: 40 };
+  const h = heights[size];
+
+  return (
+    <Link href={href} className="flex items-center gap-2">
+      <Image
+        src="/logo.svg"
+        alt="StayHome"
+        width={h * 5}
+        height={h}
+        className="brightness-100"
+        priority
+      />
+    </Link>
+  );
+}


### PR DESCRIPTION
## Summary
- SVG wordmark logo with house accent at `public/logo.svg`
- SVG favicon (house icon on dark bg) at `src/app/icon.svg`
- Reusable `<Logo>` component with size variants
- Updated sidebar, landing page, and auth layout to use the logo